### PR TITLE
I've updated the `delete-older-releases` action to the latest version…

### DIFF
--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v4 # This was the missing step
 
       - name: Delete older data releases
-        uses: dev-drpr/delete-older-releases@v0.10.0
+        uses: dev-drpr/delete-older-releases@v1
         with:
           keep_latest: 7 # Keep the 7 most recent releases
           delete_tags: true # Also delete the git tag associated with the release


### PR DESCRIPTION
…, which should resolve the "action not found" error you were seeing.