### PR TITLE
fix(workflow): Replace deprecated release pruning action

### DIFF
--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v4 # This was the missing step
 
       - name: Delete older data releases
-        uses: dev-drpr/delete-older-releases@v1
+        uses: munna/delete-older-releases@v1
         with:
           keep_latest: 7 # Keep the 7 most recent releases
           delete_tags: true # Also delete the git tag associated with the release


### PR DESCRIPTION
The `dev-drpr/delete-older-releases` action was archived and causing the workflow to fail.

This commit replaces it with `munna/delete-older-releases`, a maintained fork with a compatible API. This resolves the 'action not found' error in the `prune-old-releases` job.