### PR TITLE
I've made a change to the release workflow.  Previously, an action wa…

### DIFF
--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -111,14 +111,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4 # This was the missing step
 
-      - name: Delete older data releases
-        uses: munna/delete-older-releases@v1
-        with:
-          keep_latest: 7 # Keep the 7 most recent releases
-          delete_tags: true # Also delete the git tag associated with the release
-          delete_tag_pattern: 'data-daily-' # IMPORTANT: Only delete tags matching our pattern
+      - name: Prune old data releases
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # List all releases with the 'data-daily-' prefix, sorted by creation date
+          # Then, skip the most recent 7 and feed the rest to the delete command.
+          gh release list --repo "$GH_REPO" --limit 100 | \
+          grep "data-daily-" | \
+          sort -r | \
+          awk 'NR > 7' | \
+          cut -f1 | \
+          while read -r tag; do
+            echo "Deleting release and tag: $tag"
+            gh release delete "$tag" --repo "$GH_REPO" --yes --cleanup-tag
+          done
 
 # Notes for user:
 # 1. GITHUB_TOKEN: The default GITHUB_TOKEN has permissions to create releases in the same repository.


### PR DESCRIPTION
…s failing, so I've replaced it with a script that uses the official GitHub CLI. This new approach is more reliable. It lists all releases, filters for those with the `data-daily-` prefix, sorts them, and then removes all but the 7 most recent releases and their associated tags. This should resolve the 'action not found' error you were seeing.