### PR TITLE
Fix data pull prune and tag cleanup

### DIFF
--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -121,17 +121,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # List all releases with the 'data-' prefix, sorted by creation date
-          # Then, skip the most recent 7 and feed the rest to the delete command.
-          gh release list --repo "$GH_REPO" --limit 100 | \
-          grep "data-" | \
-          sort -r | \
-          awk 'NR > 7' | \
-          cut -f1 | \
+          set -euo pipefail
+          DATA_PREFIX="data-daily-"
+          echo "Finding data releases with prefix '${DATA_PREFIX}' to prune (keeping latest 7)..."
+          gh release list --repo "$GH_REPO" --limit 100 --json tagName,name,createdAt,publishedAt | \
+          jq -r --arg prefix "$DATA_PREFIX" '[.[] | select(.tagName|startswith($prefix))] | sort_by(.publishedAt // .createdAt // "") | reverse | .[7:] | .[].tagName' | \
           while read -r tag; do
+            if [ -z "$tag" ]; then
+              continue
+            fi
             echo "Deleting release and tag: $tag"
-            gh release delete "$tag" --repo "$GH_REPO" --yes --cleanup-tag
+            if ! gh release delete "$tag" --repo "$GH_REPO" --yes --cleanup-tag; then
+              echo "Release deletion failed for $tag. Attempting to delete tag ref only..."
+              gh api --method DELETE "repos/$GH_REPO/git/refs/tags/$tag" || echo "Tag ref deletion failed for $tag"
+            fi
           done
+          echo "Prune complete."
 
 # Notes for user:
 # 1. GITHUB_TOKEN: The default GITHUB_TOKEN has permissions to create releases in the same repository.


### PR DESCRIPTION
Refactor the data release pruning job to reliably delete old data releases and their corresponding tags using `gh` CLI with JSON output, fixing the "release not found" error.

The previous pruning logic used brittle text parsing (`grep`, `sort`, `awk`, `cut`) on `gh release list` output, which often resulted in attempting to delete releases by their display name instead of the actual tag name, leading to "release not found" errors. This PR switches to using `gh release list --json` and `jq` to accurately identify and delete releases by their `tagName`, ensuring proper cleanup of both the release and its associated tag.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5aa442f-10cc-480d-a14a-7f2e4b490e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5aa442f-10cc-480d-a14a-7f2e4b490e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

