### PR TITLE
Debug stuck data build loading

### DIFF
--- a/docs/assets/js/one/ui.js
+++ b/docs/assets/js/one/ui.js
@@ -5,12 +5,12 @@
 
 // Note: The paths are relative to the final location in the 'docs' directory.
 // We use absolute paths from the site root to ensure they resolve correctly.
-import { getLatestEtudeData } from '/assets/js/core/data_fetcher.js';
-import { setHtml, updateStatusFooter } from '/assets/js/core/ui_updater.js';
-import { SkinContextFactory, SkinManager } from '/assets/js/core/skin_manager.js';
-import { shadeDay, shadeNight } from '/assets/skins/shade.js';
-import { sunMorning, sunAfternoon, sunEvening, sunNight } from '/assets/skins/sun.js';
-import { defaultSkin } from '/assets/skins/default.js';
+import { getLatestEtudeData } from '../core/data_fetcher.js';
+import { setHtml, updateStatusFooter } from '../core/ui_updater.js';
+import { SkinContextFactory, SkinManager } from '../core/skin_manager.js';
+import { shadeDay, shadeNight } from '../../skins/shade.js';
+import { sunMorning, sunAfternoon, sunEvening, sunNight } from '../../skins/sun.js';
+import { defaultSkin } from '../../skins/default.js';
 
 // --- CONFIGURATION ---
 // These should be replaced by your actual GitHub repo details.
@@ -26,7 +26,7 @@ const REPO_NAME = 'test-1';
  */
 async function getTemplate() {
     // Use an absolute path from the site root to fetch the template
-    const response = await fetch('/assets/js/one/templates/content.mustache');
+    const response = await fetch('../assets/js/one/templates/content.mustache');
     if (!response.ok) {
         throw new Error('Failed to fetch content.mustache template');
     }

--- a/docs/assets/js/zero/ui.js
+++ b/docs/assets/js/zero/ui.js
@@ -4,12 +4,12 @@
  * displaying the status of all other etudes.
  */
 
-import { getLatestEtudeData } from '/assets/js/core/data_fetcher.js';
-import { setHtml, updateStatusFooter } from '/assets/js/core/ui_updater.js';
-import { SkinContextFactory, SkinManager } from '/assets/js/core/skin_manager.js';
-import { shadeDay, shadeNight } from '/assets/skins/shade.js';
-import { sunMorning, sunAfternoon, sunEvening, sunNight } from '/assets/skins/sun.js';
-import { defaultSkin } from '/assets/skins/default.js';
+import { getLatestEtudeData } from '../core/data_fetcher.js';
+import { setHtml, updateStatusFooter } from '../core/ui_updater.js';
+import { SkinContextFactory, SkinManager } from '../core/skin_manager.js';
+import { shadeDay, shadeNight } from '../../skins/shade.js';
+import { sunMorning, sunAfternoon, sunEvening, sunNight } from '../../skins/sun.js';
+import { defaultSkin } from '../../skins/default.js';
 
 // --- CONFIGURATION ---
 const REPO_OWNER = 'greple-test';
@@ -22,7 +22,7 @@ const REPO_NAME = 'test-1';
  */
 async function getTemplate() {
     // Use an absolute path from the site root to fetch the template
-    const response = await fetch('/assets/js/zero/templates/status_table.mustache');
+    const response = await fetch('../assets/js/zero/templates/status_table.mustache');
     if (!response.ok) {
         throw new Error('Failed to fetch status_table.mustache template');
     }

--- a/docs/assets/skins/default.js
+++ b/docs/assets/skins/default.js
@@ -5,7 +5,7 @@ import { BaseSkin } from './base_skin.js';
 export const defaultSkin = new BaseSkin({
     name: 'default',
     tags: [],
-    css_file: '/assets/skins/css/default.css',
+    css_file: '../assets/skins/css/default.css',
     // It can rely on the default widget classes from BaseSkin,
     // or define its own if needed.
     widget_classes: {

--- a/docs/assets/skins/shade.js
+++ b/docs/assets/skins/shade.js
@@ -10,7 +10,7 @@ const shadeDayClasses = {
 export const shadeDay = new BaseSkin({
     name: 'shade_day',
     tags: ['day_period:day'],
-    css_file: '/assets/skins/css/shade.css',
+    css_file: '../assets/skins/css/shade.css',
     widget_classes: shadeDayClasses,
 });
 
@@ -25,6 +25,6 @@ const shadeNightClasses = {
 export const shadeNight = new BaseSkin({
     name: 'shade_night',
     tags: ['day_period:night'],
-    css_file: '/assets/skins/css/shade.css',
+    css_file: '../assets/skins/css/shade.css',
     widget_classes: shadeNightClasses,
 });

--- a/docs/assets/skins/sun.js
+++ b/docs/assets/skins/sun.js
@@ -7,7 +7,7 @@ import { BaseSkin } from './base_skin.js';
 export const sunMorning = new BaseSkin({
     name: 'sun_morning',
     tags: ['time_of_day:morning'],
-    css_file: '/assets/skins/css/sun.css',
+    css_file: '../assets/skins/css/sun.css',
     widget_classes: {
         title: 'sun-title-morning',
         body: 'sun-body-morning',
@@ -18,7 +18,7 @@ export const sunMorning = new BaseSkin({
 export const sunAfternoon = new BaseSkin({
     name: 'sun_afternoon',
     tags: ['time_of_day:afternoon'],
-    css_file: '/assets/skins/css/sun.css',
+    css_file: '../assets/skins/css/sun.css',
     widget_classes: {
         title: 'sun-title-afternoon',
         body: 'sun-body-afternoon',
@@ -32,7 +32,7 @@ export const sunAfternoon = new BaseSkin({
 export const sunEvening = new BaseSkin({
     name: 'sun_evening',
     tags: ['time_of_day:evening'],
-    css_file: '/assets/skins/css/sun.css',
+    css_file: '../assets/skins/css/sun.css',
     widget_classes: {
         title: 'sun-title-evening',
         body: 'sun-body-evening',
@@ -44,7 +44,7 @@ export const sunEvening = new BaseSkin({
 export const sunNight = new BaseSkin({
     name: 'sun_night',
     tags: ['time_of_day:night'],
-    css_file: '/assets/skins/css/sun.css',
+    css_file: '../assets/skins/css/sun.css',
     widget_classes: {
         title: 'sun-title-night',
         body: 'sun-body-night',

--- a/docs/one/index.html
+++ b/docs/one/index.html
@@ -53,13 +53,13 @@
 
     <!-- Import the Mustache module and attach it to the window object to make it globally accessible -->
     <script type="module">
-        import Mustache from '/assets/js/vendor/mustache.min.js';
+        import Mustache from '../assets/js/vendor/mustache.min.js';
         window.Mustache = Mustache;
     </script>
 
     <!-- Load our application modules -->
-    <script type="module" src="/assets/js/core/data_fetcher.js"></script>
-    <script type="module" src="/assets/js/core/ui_updater.js"></script>
-    <script type="module" src="/assets/js/one/ui.js"></script>
+    <script type="module" src="../assets/js/core/data_fetcher.js"></script>
+    <script type="module" src="../assets/js/core/ui_updater.js"></script>
+    <script type="module" src="../assets/js/one/ui.js"></script>
 </body>
 </html>

--- a/docs/zero/index.html
+++ b/docs/zero/index.html
@@ -60,13 +60,13 @@
 
     <!-- Import the Mustache module and attach it to the window object to make it globally accessible -->
     <script type="module">
-        import Mustache from '/assets/js/vendor/mustache.min.js';
+        import Mustache from '../assets/js/vendor/mustache.min.js';
         window.Mustache = Mustache;
     </script>
 
     <!-- Load our application modules -->
-    <script type="module" src="/assets/js/core/data_fetcher.js"></script>
-    <script type="module" src="/assets/js/core/ui_updater.js"></script>
-    <script type="module" src="/assets/js/zero/ui.js"></script>
+    <script type="module" src="../assets/js/core/data_fetcher.js"></script>
+    <script type="module" src="../assets/js/core/ui_updater.js"></script>
+    <script type="module" src="../assets/js/zero/ui.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fix absolute asset paths to relative paths to enable scripts and CSS to load correctly on GitHub Pages.

The previous absolute paths (`/assets/...`) caused 404 errors when served from a subpath on GitHub Pages, preventing JavaScript modules from loading and executing, which resulted in a perpetually stuck loading state and no console logs.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd83e81d-ace9-46ef-9ba5-6bb8a06db29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd83e81d-ace9-46ef-9ba5-6bb8a06db29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

